### PR TITLE
Add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+IMAGE_TAG := inngest-lambda
+INNGEST_REGISTER_URL := http://host.docker.internal:8288/fn/register
+PORT := 9000
+
+build:
+	docker build -t $(IMAGE_TAG) .
+
+run:
+	docker run -p $(PORT):8080 -e INNGEST_REGISTER_URL=$(INNGEST_REGISTER_URL) $(IMAGE_TAG)
+
+dev-server:
+	npx inngest-cli@latest dev -u http://localhost:$(PORT)/2015-03-31/functions/function/invocations

--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ This is an [AWS Lambda container image](https://docs.aws.amazon.com/lambda/lates
 
 ## Getting Started
 
-```bash
-# Build and start
-npm install
-docker build -t example .
-docker run -p 9000:8080 example
+Build and run your Lambda image locally:
 
-# Test
-curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'
+```bash
+npm install
+make build
+make run
+```
+
+Run the Inngest dev server:
+
+```
+make dev-server
 ```
 
 ## Learn More

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,9 @@ const fn = inngest.createFunction(
   { event: "test/hello.world" },
   async ({ event }) => {
     return "Hello World";
-  }
+  },
 );
 
-export const handler = serve(inngest, [fn]);
+export const handler = serve(inngest, [fn], {
+  inngestRegisterUrl: process.env.INNGEST_REGISTER_URL,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/node": "^20.7.2",
         "inngest": "^2.7.2"
       },
       "devDependencies": {
@@ -366,6 +367,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "20.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.2.tgz",
+      "integrity": "sha512-RcdC3hOBOauLP+r/kRt27NrByYtDjsXyAuSbR87O6xpsvi763WI+5fbSIvYJrXnt9w4RuxhV6eAXfIs7aaf/FQ=="
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "esbuild": "^0.17.12"
   },
   "dependencies": {
+    "@types/node": "^20.7.2",
     "inngest": "^2.7.2"
   }
 }


### PR DESCRIPTION
## Purpose 

Since there are 3 key commands that developers need to run (docker build, docker run, and the dev server) each with specific parameters, we can use a Make file to simplify the commands that the end user has to run. As they're all documented in the the Makefile, the developer can modify and change these however they want and they don't need to remember the exact commands from the README.

## Notes

* This does add a dependency with Make, which may not be ideal. We could alternatively use a shell script.